### PR TITLE
Implementation of hierarchies and numbering

### DIFF
--- a/delta-lang/src/components/math-blocks.js
+++ b/delta-lang/src/components/math-blocks.js
@@ -8,9 +8,27 @@ class DeltaBlock extends HTMLElement {
     const title = this.getAttribute("data-title") || null
     const level = this.getAttribute("data-level") || null
     const type = this.getAttribute("data-type") || null
+    const number = this.getAttribute("data-number") || null
 
     const blockHeader = document.createElement("div")
-    blockHeader.textContent = title ? `${type} (${title}).` : `${type}.`
+
+    // Construct header with number
+
+    let headerText = type || 'Block';
+
+    // Capitalize type (optional, but looks nicer if type is lowercase)
+    headerText = headerText.charAt(0).toUpperCase() + headerText.slice(1);
+
+    if (number) {
+      headerText += ` ${number}`
+    }
+    if (title) {
+            headerText += ` (${title})`;
+        }
+        
+    headerText += "."; // add the final dot
+
+    blockHeader.textContent = headerText;
     blockHeader.classList.add("block-header")
 
     if (level) {

--- a/delta-lang/src/core/parser.js
+++ b/delta-lang/src/core/parser.js
@@ -1,12 +1,13 @@
 // ----- Padrões -----
 
 // Seção - Identifica uma linha de seção, que começa com 1 a 6 '#' seguidos de espaço dependendo do nível.
-const SECTION_PATTERN = /^#{1,6}\s/;
+// Modificado: permite um * opcional para marcar ausência de numeração na seção (eg. #* ##*...)
+const SECTION_PATTERN = /^#{1,6}\*?\s/;
 
 // Bloco Simples - Identifica um 'bloco simples', isto é, uma linha que contém ':' e tem conteúdo depois.
 const SIMPLE_BLOCK_PATTERN = new RegExp([
   '^',
-  '([a-z][a-zA-Z0-9_]*)', // equation
+  '([a-z][a-zA-Z0-9_]*\\*?)', // equation
   '(?:\\s+"([^"]*)")?', // equation "title"
   '(?:\\s*,?\\s+([a-z][a-zA-Z0-9_-]*\\s+"[^"]*"))*', // equation "title", attr "value" ...
   '\\s*:\\s*', // colon outside quotes
@@ -16,13 +17,13 @@ const SIMPLE_BLOCK_PATTERN = new RegExp([
 // Bloco Complexo - Identifica um 'bloco complexo': uma linha que termina com ':' e cujo conteúdo está nas linhas seguintes.
 const COMPLEX_BLOCK_PATTERN = new RegExp([
   '^(',
-    '[a-z][a-zA-Z0-9_]*\\s*', // 1. theorem
+    '[a-z][a-zA-Z0-9_]*\\*?\\s*', // 1. theorem
     '|',
-    '[a-z][a-zA-Z0-9_]*\\s+"[^"]*"\\s*', // 2. theorem "title"
+    '[a-z][a-zA-Z0-9_]*\\*?\\s+"[^"]*"\\s*', // 2. theorem "title"
     '|',
-    '[a-z][a-zA-Z0-9_]*(?:\\s+[a-z][a-zA-Z0-9_-]*\\s+"[^"]*")+', // 3. theorem attr "value" ...
+    '[a-z][a-zA-Z0-9_]*\\*?(?:\\s+[a-z][a-zA-Z0-9_-]*\\s+"[^"]*")+', // 3. theorem attr "value" ...
     '|',
-    '[a-z][a-zA-Z0-9_]*\\s+"[^"]*"\\s*,\\s*(?:[a-z][a-zA-Z0-9_-]*\\s+"[^"]*")(?:\\s+[a-z][a-zA-Z0-9_-]*\\s+"[^"]*")*', // 4. theorem "title", attr "value" ...
+    '[a-z][a-zA-Z0-9_]*\\*?\\s+"[^"]*"\\s*,\\s*(?:[a-z][a-zA-Z0-9_-]*\\s+"[^"]*")(?:\\s+[a-z][a-zA-Z0-9_-]*\\s+"[^"]*")*', // 4. theorem "title", attr "value" ...
   ')\\s*:\\s*$'
 ].join(''), 'm');
 
@@ -83,7 +84,9 @@ class Parser {
         
         if (this.matchSection(trimmed)) {
             const section = this.parseSection(trimmed, indent)
-            this.addToHierarchy(section)
+
+            // Changed
+            this.addSectionToHierarchy(section)
             
         } else if (this.matchSimpleBlock(trimmed)) {
             const [simpleBlock, afterColon] = this.parseSimpleBlock(trimmed, indent)
@@ -105,8 +108,8 @@ class Parser {
         } else {
             if (trimmed !== '') {
                 //const escapedTrimmedLine = this.handleBackslashes(line).trimStart()
-                const trimmed = line.trimStart()
-                this.createParagraphFromSubLine(trimmed, indent)
+                const trimmedContent = line.trimStart() // Renamed to avoid conflict with top-level "trimmed"
+                this.createParagraphFromSubLine(trimmedContent, indent)
             } else if (this.stack[this.stack.length-1].type === 'paragraph' && this.stack[this.stack.length-1].children.length !== 0) {
                 this.addToHierarchy({
                     type: 'paragraph',
@@ -114,6 +117,80 @@ class Parser {
                     indent: this.stack[this.stack.length-1].indent
                 })
             }
+        }
+    }
+
+    // NEW METHOD: Handles the logic for Sections (Title, Section, Subsection)
+
+    addSectionToHierarchy(newSection) {
+        // 1. First, we must close any "non-section" blocks that might still be open 
+        // (like a Theorem or Note that wasn't closed properly), because a Section breaks everything.
+        while (this.stack.length > 1) {
+            const top = this.stack[this.stack.length - 1];
+
+            // If the top is not a section, we close it (pop)
+            if (top.type !== 'section') {
+                this.stack.pop();
+            } else {
+                // if it is a section, we stop to check the levels
+                break;
+            }
+        }
+
+        // 2. Now we handle Section nesting based on level (#)
+        // We pop the stack until we find a parent Section with a 'level' strictly less than our new section (when we find, it will be the parent).
+        // Example: If stack is [Section 1 (Lvl 1), Subsection 1.1 (Lvl 2)] and we add Section 2 (Lvl 1):
+        // We pop Subsection 1.1 (2 >= 1).
+        // We pop Section 1 (1 >= 1).
+        // We attach Section 2 to Root.
+
+        while (this.stack.length > 1) {
+            const top = this.stack[this.stack.length - 1];
+
+            if (top.type === 'section' && top.level >= newSection.level) {
+                this.stack.pop();
+            } else {
+                break;
+            }
+        }
+
+        // 3. Add the valid parent and push to stack
+
+        const parent = this.stack[this.stack.length - 1];
+        parent.children.push(newSection);
+        this.stack.push(newSection);
+    }
+
+    // Modified method: handles standard hierarchy (paragraph, blocks) based on indentation
+
+    addToHierarchy(element) {
+        // Pop stack until we find the correct parent
+        while (this.stack.length > 1) {
+            const parent = this.stack[this.stack.length - 1];
+
+            // If a parent is a 'section', we never pop it based on indentation 
+            // Sections act as permanent containers until we close them with addSectionToHierarchy 
+            if (parent.type === 'section') {
+                break;
+            }
+
+            // For other blocks (like theorems, lists, etc), we use indentation to define belonging
+
+            if (parent.indent < element.indent) {
+                break;
+            }
+
+            this.stack.pop()
+        }
+
+        // Add to current parent
+
+        const parent = this.stack[this.stack.length -1]
+        parent.children.push(element)
+
+        // Push onto the stack if the element can have children
+        if (element.children !== undefined) {
+            this.stack.push(element)
         }
     }
 
@@ -228,16 +305,33 @@ class Parser {
 
     parseSection(line, indent) {
         const escapedLine = this.handleBackslashes(line);
-        const level = (escapedLine.match(/^#+/) || [''])[0].length
-        const title = escapedLine.replace(/^#+\s+/, '')
+
+        // Check for '*' before the title starts.
+        // Matches beginning like "##*"
+
+        const isUnnumbered = /^#+\*/.test(escapedLine);
+
+        const level = (escapedLine.match(/^#+/) || [''])[0].length;
+
+        // Clean title: remove hashes, optional star, and spaces
+        const title = escapedLine.replace(/^#+\*?\s+/, '');
         
         return {
             type: 'section',
             level: level,
+            isUnnumbered: isUnnumbered,
             title: title,
             indent: indent,
             children: []
         }
+    }
+
+    // Helper to extract type and unnumbered status
+    parseBlockType(rawType) {
+        const isUnnumbered = rawType.endsWith('*');
+        // slice(0, -1) removes the last character ('*')
+        const blockType = isUnnumbered ? rawType.slice(0, -1) : rawType;
+        return {blockType, isUnnumbered};
     }
 
     parseBlock(line, indent) {
@@ -248,25 +342,30 @@ class Parser {
         if (unescapedColons.length === 0) return null
         // if (unescapedColons.length > 1) return null // pensar se vamos fazer isso mesmo
 
-        const colonIndex = unescapedColons[0]
+        const colonIndex = unescapedColons[0];
         
         const escapedLine = this.handleBackslashes(line);
-        const beforeColon = escapedLine.substring(0, colonIndex).trim()
-        const afterColon = escapedLine.substring(colonIndex + 1).trim()
+        const beforeColon = escapedLine.substring(0, colonIndex).trim();
+        const afterColon = escapedLine.substring(colonIndex + 1).trim();
         
         // Parse the part before colon for blockType and attributes
-        const spaceIndex = beforeColon.indexOf(' ')
-        let blockType, attributeText
+        const spaceIndex = beforeColon.indexOf(' ');
+
+        let rawType, attributeText;
         
         if (spaceIndex === -1) {
             // Simple case: "theorem:"
-            blockType = beforeColon
-            attributeText = ''
+            rawType = beforeColon;
+            attributeText = '';
         } else {
             // Complex case: "theorem 'Pythagorean'"
-            blockType = beforeColon.substring(0, spaceIndex)
-            attributeText = beforeColon.substring(spaceIndex + 1).trim()
+            rawType = beforeColon.substring(0, spaceIndex);
+            attributeText = beforeColon.substring(spaceIndex + 1).trim();
         }
+
+        // Extract the cleanblock format 
+        const {blockType, isUnnumbered} = this.parseBlockType(rawType);
+
         
         let title = null, attributes = {}
         if (attributeText) {
@@ -277,7 +376,8 @@ class Parser {
         
         const block = {
             type: 'block',
-            blockType: blockType,
+            blockType: blockType, // eg. theorem (clean, not theorem*)
+            isUnnumbered: isUnnumbered,
             indent: indent,
             children: []
         }
@@ -303,29 +403,34 @@ class Parser {
         if (unescapedColons.length === 0) return null
         // if (unescapedColons.length > 1) return null // pensar se vamos fazer isso mesmo
 
-        const colonIndex = unescapedColons[0]
+        const colonIndex = unescapedColons[0];
 
         const escapedLine = this.handleBackslashes(line);
-        const beforeColon = escapedLine.substring(0, colonIndex).trim()
-        const afterColon = escapedLine.substring(colonIndex + 1).trim()
+        const beforeColon = escapedLine.substring(0, colonIndex).trim();
+        const afterColon = escapedLine.substring(colonIndex + 1).trim();
         
         // Parse the part before colon for blockType and attributes
-        const spaceIndex = beforeColon.indexOf(' ')
-        let blockType, attributeText
+        const spaceIndex = beforeColon.indexOf(' ');
+
+        let rawType, attributeText;
         
         if (spaceIndex === -1) {
             // Simple case: "theorem:"
-            blockType = beforeColon
+            rawType = beforeColon
             attributeText = ''
         } else {
             // Complex case: "equation id 'eq':"
-            blockType = beforeColon.substring(0, spaceIndex)
+            rawType = beforeColon.substring(0, spaceIndex)
             attributeText = beforeColon.substring(spaceIndex + 1).trim()
         }
         
+        // Extract * logic
+        const {blockType, isUnnumbered} = this.parseBlockType(rawType);
+
         const block = {
             type: 'simple-block',
             blockType: blockType,
+            isUnnumbered: isUnnumbered,
             indent: indent,
             children: []
         }
@@ -358,23 +463,6 @@ class Parser {
         }
         
         return { title, attributes }
-    }
-
-    addToHierarchy(element) {
-        // Pop stack until we find correct parent
-        while (this.stack.length > 1 && 
-               this.stack[this.stack.length - 1].indent >= element.indent) {
-            this.stack.pop()
-        }
-        
-        // Add to current parent
-        const parent = this.stack[this.stack.length - 1]
-        parent.children.push(element)
-        
-        // Push onto stack if this element can have children
-        if (element.children !== undefined) {
-            this.stack.push(element)
-        }
     }
 
     getIndent(line) {

--- a/delta-lang/src/renderer/html-renderer.js
+++ b/delta-lang/src/renderer/html-renderer.js
@@ -66,15 +66,14 @@ class DeltaRenderer {
      * Numbering algorithm
      * Handles numbered/unnumbered sections and inherited numbering contexts
      */
-    calculateNumbering(node, prefix = '0', inheritedCounters = null) {
+    calculateNumbering(node, sectionPrefix = '0', mathPrefix = '0', inheritedCounters = null) {
         // If this node is a leaf (text) or has no children, stop.
         if (!node.children) return;
 
-        // We prepare to count the children of THIS node.
         let sectionCounter = 0;
         
-        // If we received counters from a parent (Section*), use them. Otherwise (eg. we entered a new valid Section), start with {}.
-        let mathCounters = inheritedCounters || {}; 
+        // If inheritedCounters is passed, we are sharing the same object (reference)
+        let mathCounters = inheritedCounters || {};
 
         // Helper to get/increment math counter
         const getMathNumber = (type, isUnnumbered) => {
@@ -83,9 +82,8 @@ class DeltaRenderer {
             if (!mathCounters[type]) mathCounters[type] = 0;
             mathCounters[type]++;
             
-            // return eg. "1.2.1" (Prefix (section). Counter (block))
-            // if prefix is "0" (no section yet), result is "0.1"
-            return `${prefix}.${mathCounters[type]}`;
+            // Change: we use 'mathPrefix' (e.g. "1"), NOT 'sectionPrefix' (e.g. "1.2")
+            return `${mathPrefix}.${mathCounters[type]}`;
         };
 
         // Pass through the children
@@ -95,24 +93,38 @@ class DeltaRenderer {
             if (child.type === 'section') {
                 
                 if (child.isUnnumbered) {
-                    this.calculateNumbering(child, prefix, mathCounters);
+                    this.calculateNumbering(child, sectionPrefix, mathPrefix, mathCounters);
                     
                 } else {
                     sectionCounter++;
                     
-                    let newPrefix;
+                    let newSectionPrefix;
 
                     // If we are at the root ('0') but this is a subsection (## or ###...),
                     // we prefix it with "0." explicitly.
-                    if (prefix === '0' && child.level > 1) {
-                         newPrefix = `0.${sectionCounter}`;
+                    if (sectionPrefix === '0' && child.level > 1) {
+                         newSectionPrefix = `0.${sectionCounter}`;
                     } else {
                          // Standard logic: If root, just "1". If nested, "1.1".
-                         newPrefix = prefix === '0' ? `${sectionCounter}` : `${prefix}.${sectionCounter}`;
+                         newSectionPrefix = sectionPrefix === '0' ? `${sectionCounter}` : `${sectionPrefix}.${sectionCounter}`;
                     }
 
-                    child.sectionNumber = newPrefix;
-                    this.calculateNumbering(child, newPrefix, {});
+                    child.sectionNumber = newSectionPrefix;
+
+                    let newMathPrefix;
+                    let nextCounters;
+
+                    if (child.level === 1) {
+                        newMathPrefix = newSectionPrefix;
+                        nextCounters = {} // Reset counters for level 1 section elements
+                    }
+                    else {
+                        newMathPrefix = mathPrefix;
+                        nextCounters = mathCounters;
+                    }
+
+
+                    this.calculateNumbering(child, newSectionPrefix, newMathPrefix, nextCounters);
                 }
             } 
             
@@ -126,13 +138,13 @@ class DeltaRenderer {
                 }
 
                 // Then we recurse deeper just in case the theorem has nested blocks (eg. an equation inside it)
-                this.calculateNumbering(child, prefix, mathCounters); 
+                this.calculateNumbering(child, sectionPrefix, mathPrefix, mathCounters); 
             }
             
             // 3rd scenario generic formatting (bold, italic, divs)
             else {
                 // Just pass the current state through
-                this.calculateNumbering(child, prefix, mathCounters);
+                this.calculateNumbering(child, sectionPrefix, mathPrefix, mathCounters);
             }
         });
     }

--- a/delta-lang/src/renderer/html-renderer.js
+++ b/delta-lang/src/renderer/html-renderer.js
@@ -16,7 +16,13 @@ class DeltaRenderer {
      */
     render(node) {
         if (!node || !node.type) return '';
-        
+
+        // Calculate numbering only once at the root document level
+        if (node.type === 'document' && !node._isNumbered) {
+            this.calculateNumbering(node);
+            node._isNumbered = true; // mark as done so we don't re-calculate in recursion
+        }
+
         switch (node.type) {
             case 'document':
                 return this.renderChildren(node.children);
@@ -55,6 +61,82 @@ class DeltaRenderer {
                 return '';
         }
     }
+
+    /**
+     * Numbering algorithm
+     * Handles numbered/unnumbered sections and inherited numbering contexts
+     */
+    calculateNumbering(node, prefix = '0', inheritedCounters = null) {
+        // If this node is a leaf (text) or has no children, stop.
+        if (!node.children) return;
+
+        // We prepare to count the children of THIS node.
+        let sectionCounter = 0;
+        
+        // If we received counters from a parent (Section*), use them. Otherwise (eg. we entered a new valid Section), start with {}.
+        let mathCounters = inheritedCounters || {}; 
+
+        // Helper to get/increment math counter
+        const getMathNumber = (type, isUnnumbered) => {
+            if (isUnnumbered) return null;
+            
+            if (!mathCounters[type]) mathCounters[type] = 0;
+            mathCounters[type]++;
+            
+            // return eg. "1.2.1" (Prefix (section). Counter (block))
+            // if prefix is "0" (no section yet), result is "0.1"
+            return `${prefix}.${mathCounters[type]}`;
+        };
+
+        // Pass through the children
+        node.children.forEach(child => {
+            
+            // 1st scenario
+            if (child.type === 'section') {
+                
+                if (child.isUnnumbered) {
+                    this.calculateNumbering(child, prefix, mathCounters);
+                    
+                } else {
+                    sectionCounter++;
+                    
+                    let newPrefix;
+
+                    // If we are at the root ('0') but this is a subsection (## or ###...),
+                    // we prefix it with "0." explicitly.
+                    if (prefix === '0' && child.level > 1) {
+                         newPrefix = `0.${sectionCounter}`;
+                    } else {
+                         // Standard logic: If root, just "1". If nested, "1.1".
+                         newPrefix = prefix === '0' ? `${sectionCounter}` : `${prefix}.${sectionCounter}`;
+                    }
+
+                    child.sectionNumber = newPrefix;
+                    this.calculateNumbering(child, newPrefix, {});
+                }
+            } 
+            
+            // 2nd scenario (Theorem, 'eq', etc.)
+            else if (child.type === 'block' || child.type === 'simple-block') {
+                // Define which blocks get numbers (add more later if necessary)
+                const numerableTypes = ['theorem', 'lemma', 'definition', 'corollary', 'proposition', 'example', 'equation'];
+
+                if (numerableTypes.includes(child.blockType)) {
+                    child.blockNumber = getMathNumber(child.blockType, child.isUnnumbered);
+                }
+
+                // Then we recurse deeper just in case the theorem has nested blocks (eg. an equation inside it)
+                this.calculateNumbering(child, prefix, mathCounters); 
+            }
+            
+            // 3rd scenario generic formatting (bold, italic, divs)
+            else {
+                // Just pass the current state through
+                this.calculateNumbering(child, prefix, mathCounters);
+            }
+        });
+    }
+
     
     /**
      * Render a bold node
@@ -108,9 +190,30 @@ class DeltaRenderer {
      */
     renderSection(node) {
         const level = Math.min(node.level, 6);
-        const sectionHTML = `<h${level}>${this.escapeHtml(node.title)}</h${level}>`;
+
+        const NumberHTML = node.sectionNumber
+            ? `<span class="section-number">${node.sectionNumber}. </span>` 
+            : '';
+
+        const safeTitle = node.title.replace(/\s+/g, '-').replace(/[^\w-]/g, '').toLowerCase();
+        const sectionId = node.sectionNumber 
+            ? `sec-${node.sectionNumber}` 
+            : `sec-u-${safeTitle}`;
+
         const childrenHTML = this.renderChildren(node.children);
-        return sectionHTML + childrenHTML;
+        
+        return `
+            <section class="delta-section level-${level}" id="${sectionId}" data-number="${node.sectionNumber || ''}">
+                <header class="section-header">
+                    <h${level}>
+                        ${NumberHTML}${this.escapeHtml(node.title)}
+                    </h${level}>
+                </header>
+                <div class="section-content">
+                    ${childrenHTML}
+                </div>
+            </section>
+        `;
     }
     
     /**
@@ -141,6 +244,10 @@ class DeltaRenderer {
         // Add the block type as attribute
         attributesStr += ` data-type="${blockType}"`
 
+        if (node.blockNumber) {
+            attributesStr += ` data-number="${node.blockNumber}"`;
+        }
+
         if (node.attributes && Object.keys(node.attributes).length > 0) {
             for (const [key, value] of Object.entries(node.attributes)) {
                 attributesStr += ` data-${key}="${this.escapeHtml(value)}"`;
@@ -162,8 +269,16 @@ class DeltaRenderer {
         const tagName = `delta-${blockType}`;
         const childrenHTML = this.renderChildren(node.children);
         
-       const  attributesStr = `data-type="${blockType}" simple`
+        let  attributesStr = `data-type="${blockType}" simple`
+
+        if (node.blockNumber) {
+            attributesStr += ` data-number="${node.blockNumber}"`;
+        }
         
+        if (node.title) {
+            attributesStr += ` data-title="${this.escapeHtml(node.title)}"` 
+        }
+
         return `<${tagName} ${attributesStr}>${childrenHTML}</${tagName}>`;
     }
     


### PR DESCRIPTION
Hierarchies implemented in the parser through manipulation of the stack elements. Each time we remove an element from the stack, we end a node branch in our abstract syntax tree. Basically, hierarchy is defined within the tree, parents have higher hierarchy than children and we use the stack to construct the tree.

Numbering done by storing in each node of the tree a counter for all its children.